### PR TITLE
[Enhance] Add a Faster Discard Method without Callbacks

### DIFF
--- a/lib/discard/model.rb
+++ b/lib/discard/model.rb
@@ -17,7 +17,7 @@ module Discard
 
     module ClassMethods
       def discard_all
-        all.each(&:discard)
+        update_all(:"#{self.discard_column}" => Time.current)
       end
       def undiscard_all
         all.each(&:undiscard)

--- a/lib/discard/model.rb
+++ b/lib/discard/model.rb
@@ -17,6 +17,10 @@ module Discard
 
     module ClassMethods
       def discard_all
+        all.each(&:discard)
+      end
+
+      def dispose_all
         update_all(:"#{self.discard_column}" => Time.current)
       end
       def undiscard_all

--- a/lib/discard/model.rb
+++ b/lib/discard/model.rb
@@ -23,8 +23,13 @@ module Discard
       def dispose_all
         update_all(:"#{self.discard_column}" => Time.current)
       end
+
       def undiscard_all
         all.each(&:undiscard)
+      end
+
+      def undispose_all
+        update_all(:"#{self.discard_column}" => nil)
       end
     end
 

--- a/spec/discard/model_spec.rb
+++ b/spec/discard/model_spec.rb
@@ -341,6 +341,42 @@ RSpec.describe Discard::Model do
     end
   end
 
+  describe '.dispose_all' do
+    with_model :Post, scope: :all do
+      table do |t|
+        t.string :title
+        t.datetime :discarded_at
+        t.timestamps null: false
+      end
+
+      model do
+        include Discard::Model
+      end
+    end
+
+    let!(:post) { Post.create!(title: "My very first post") }
+    let!(:post2) { Post.create!(title: "A second post") }
+
+    it "can dispose all posts" do
+      expect {
+        Post.dispose_all
+      }.to   change { post.reload.discarded? }.to(true)
+        .and change { post2.reload.discarded? }.to(true)
+    end
+
+    it "can dispose a single post" do
+      Post.where(id: post.id).dispose_all
+      expect(post.reload).to be_discarded
+      expect(post2.reload).not_to be_discarded
+    end
+
+    it "can dispose no records" do
+      Post.where(id: []).dispose_all
+      expect(post.reload).not_to be_discarded
+      expect(post2.reload).not_to be_discarded
+    end
+  end
+
   describe '.undiscard_all' do
     with_model :Post, scope: :all do
       table do |t|

--- a/spec/discard/model_spec.rb
+++ b/spec/discard/model_spec.rb
@@ -377,6 +377,42 @@ RSpec.describe Discard::Model do
     end
   end
 
+  describe '.undispose_all' do
+    with_model :Post, scope: :all do
+      table do |t|
+        t.string :title
+        t.datetime :discarded_at
+        t.timestamps null: false
+      end
+
+      model do
+        include Discard::Model
+      end
+    end
+
+    let!(:post) { Post.create!(title: "My very first post", discarded_at: Time.now) }
+    let!(:post2) { Post.create!(title: "A second post", discarded_at: Time.now) }
+
+    it "can undispose all posts" do
+      expect {
+        Post.undispose_all
+      }.to   change { post.reload.discarded? }.to(false)
+        .and change { post2.reload.discarded? }.to(false)
+    end
+
+    it "can undispose a single post" do
+      Post.where(id: post.id).undispose_all
+      expect(post.reload).not_to be_discarded
+      expect(post2.reload).to be_discarded
+    end
+
+    it "can undispose no records" do
+      Post.where(id: []).undispose_all
+      expect(post.reload).to be_discarded
+      expect(post2.reload).to be_discarded
+    end
+  end
+
   describe '.undiscard_all' do
     with_model :Post, scope: :all do
       table do |t|


### PR DESCRIPTION
### Objective

Since the update query results in a for loop, might cause regression for plenty of data

### Feature

I've added `dispose_all` compare to the original `.each` loop `discard` with callbacks, replaced with one single `update_all` query which might be more performant for certain usage like `delete_all` in ActiveRecord.