### PR TITLE
Add index to migration example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ end
 class AddDiscardToPosts < ActiveRecord::Migration[5.0]
   def up
     add_column :posts, :discarded_at, :datetime
+    add_index :posts, :discarded_at
   end
 end
 ```


### PR DESCRIPTION
Discovered I was missing an index cause I copied from the readme.