### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ and awkward behaviour.
     joins and eager-loading.
 * `delete` is overridden (`really_delete` will actually delete the record) :unamused:
 * `destroy` is overridden (`really_destroy` will actually delete the record) :pensive:
+* `delete_all` is overridden (`orig_delete_all` will actually delete the collection) :unamused:
 * `dependent: :destroy` associations are deleted when performing soft-destroys :scream:
   * requiring any dependent records to also be `acts_as_paranoid` to avoid losing data. :grimacing:
 


### PR DESCRIPTION
`delete_all` method is also overwritten, which can be used as originally intended through `orig_delete_all`. This totally blew my mind, because the affix `really_`, which was used for the other methods, is not used in this case.