### PR TITLE
Improve discard_all and undiscard_all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 env:
   matrix:
     - RAILS_VERSION='~> 4.2.0'

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,8 @@
+--protected
+--no-private
+--embed-mixin ClassMethods
+-
+README.md
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+LICENSE.txt

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ class Post < ActiveRecord::Base
 end
 ```
 
+*Warning:* Please note that callbacks for save and update are run when discarding/undiscarding a record 
+
 **Working with Devise**
 
 A common use case is to apply discard to a User record. Even though a user has been discarded they can still login and continue their session.

--- a/discard.gemspec
+++ b/discard.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", '>= 4.2', '< 6'
+  spec.add_dependency "activerecord", ">= 4.2", "< 6"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.5.0"

--- a/lib/discard/version.rb
+++ b/lib/discard/version.rb
@@ -1,3 +1,4 @@
 module Discard
-  VERSION = "1.0.0"
+  # Discard version
+  VERSION = "1.0.0".freeze
 end


### PR DESCRIPTION
Simplify `discard` and `undiscard` methods
 - remove with_transaction_returning_status, run_callbacks should return the result of the block
 - use update_attribute as no validation should be performed to discard (same as with destroy)

Scope `discard_all` to only kept records, `#discard` will not change them and this can save some iterations and help to return only affected records at the end of the query (more like `destroy_all`)

Scope `discard_all` to only discarded records, `#undiscard` will not change them and this can save some iterations and help to return only affected records at the end of the query (more like `destroy_all`)

Update README to clarify that save and update callbacks are run when discarding/undiscarding

Update travis ruby versions

Add .yardopts