### PR TITLE
Add bang(!) methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
-# Version 1.0.0
+### Unreleased
+* enhancements
+  * `discard_all` and `undiscard_all` now return affected records
+  * Add `discard!` and `undiscard!`
+  
+### Version 1.0.0
 Release date: 2018-03-16
 
 * Add undiscard callbacks and `.undiscard_all`
 
-# Version 0.2.0
+### Version 0.2.0
 Release date: 2017-11-22
 
 * Add `.discard_all`
 * Add `undiscarded` scope
 * Add callbacks
 
-# Version 0.1.0
+### Version 0.1.0
 Release date: 2017-04-28
 
 * Initial version!

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,8 @@
-require "bundler/gem_tasks"
+require 'bundler/setup'
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
-begin
-  require 'rspec/core/rake_task'
-  RSpec::Core::RakeTask.new(:spec)
-rescue LoadError
-end
+RSpec::Core::RakeTask.new(:rspec)
 
-task :default => :spec
+desc 'Run the test suite'
+task default: :rspec

--- a/discard.gemspec
+++ b/discard.gemspec
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'discard/version'

--- a/lib/discard.rb
+++ b/lib/discard.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 require "active_record"
 
 require "discard/version"
+require "discard/errors"
 require "discard/model"

--- a/lib/discard/errors.rb
+++ b/lib/discard/errors.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Discard
+  # = Discard Errors
+  #
+  # Generic exception class.
+  class DiscardError < StandardError
+  end
+
+  # Raised by {Discard::Model#discard!}
+  class RecordNotDiscarded < DiscardError
+    attr_reader :record
+
+    def initialize(message = nil, record = nil)
+      @record = record
+      super(message)
+    end
+  end
+
+  # Raised by {Discard::Model#undiscard!}
+  class RecordNotUndiscarded < DiscardError
+    attr_reader :record
+
+    def initialize(message = nil, record = nil)
+      @record = record
+      super(message)
+    end
+  end
+end

--- a/lib/discard/model.rb
+++ b/lib/discard/model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Discard
   # Handles soft deletes of records.
   #
@@ -66,7 +68,7 @@ module Discard
       self[self.class.discard_column].present?
     end
 
-    # Discard record
+    # Discard the record in the database
     #
     # @return [Boolean] true if successful, otherwise false
     def discard
@@ -76,7 +78,19 @@ module Discard
       end
     end
 
-    # Undiscard record
+    # Discard the record in the database
+    #
+    # There's a series of callbacks associated with #discard!. If the
+    # <tt>before_discard</tt> callback throws +:abort+ the action is cancelled
+    # and #discard! raises {Discard::RecordNotDiscarded}.
+    #
+    # @return [Boolean] true if successful
+    # @raise {Discard::RecordNotDiscarded}
+    def discard!
+      discard || _raise_record_not_discarded
+    end
+
+    # Undiscard the record in the database
     #
     # @return [Boolean] true if successful, otherwise false
     def undiscard
@@ -84,6 +98,28 @@ module Discard
       run_callbacks(:undiscard) do
         update_attribute(self.class.discard_column, nil)
       end
+    end
+
+    # Discard the record in the database
+    #
+    # There's a series of callbacks associated with #undiscard!. If the
+    # <tt>before_undiscard</tt> callback throws +:abort+ the action is cancelled
+    # and #undiscard! raises {Discard::RecordNotUndiscarded}.
+    #
+    # @return [Boolean] true if successful
+    # @raise {Discard::RecordNotUndiscarded}
+    def undiscard!
+      undiscard || _raise_record_not_undiscarded
+    end
+
+    private
+
+    def _raise_record_not_discarded
+      raise ::Discard::RecordNotDiscarded.new("Failed to discard the record", self)
+    end
+
+    def _raise_record_not_undiscarded
+      raise ::Discard::RecordNotUndiscarded.new("Failed to undiscard the record", self)
     end
   end
 end

--- a/lib/discard/version.rb
+++ b/lib/discard/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Discard
   # Discard version
   VERSION = "1.0.0".freeze

--- a/spec/discard/model_spec.rb
+++ b/spec/discard/model_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Discard::Model do
   context "with simple Post model" do
     with_model :Post, scope: :all do
@@ -49,6 +51,20 @@ RSpec.describe Discard::Model do
         end
       end
 
+      describe '#discard!' do
+        it "sets discarded_at" do
+          expect {
+            post.discard!
+          }.to change { post.discarded_at }
+        end
+
+        it "sets discarded_at in DB" do
+          expect {
+            post.discard!
+          }.to change { post.reload.discarded_at }
+        end
+      end
+
       describe '#undiscard' do
         it "doesn't change discarded_at" do
           expect {
@@ -60,6 +76,14 @@ RSpec.describe Discard::Model do
           expect {
             post.undiscard
           }.not_to change { post.reload.discarded_at }
+        end
+      end
+
+      describe '#undiscard!' do
+        it "raises Discard::RecordNotUndiscarded" do
+          expect {
+            post.undiscard!
+          }.to raise_error(Discard::RecordNotUndiscarded)
         end
       end
     end
@@ -101,6 +125,14 @@ RSpec.describe Discard::Model do
         end
       end
 
+      describe '#discard!' do
+        it "raises Discard::RecordNotDiscarded" do
+          expect {
+            post.discard!
+          }.to raise_error(Discard::RecordNotDiscarded)
+        end
+      end
+
       describe '#undiscard' do
         it "clears discarded_at" do
           expect {
@@ -111,6 +143,20 @@ RSpec.describe Discard::Model do
         it "clears discarded_at in DB" do
           expect {
             post.undiscard
+          }.to change { post.reload.discarded_at }.to(nil)
+        end
+      end
+
+      describe '#undiscard!' do
+        it "clears discarded_at" do
+          expect {
+            post.undiscard!
+          }.to change { post.discarded_at }.to(nil)
+        end
+
+        it "clears discarded_at in DB" do
+          expect {
+            post.undiscard!
           }.to change { post.reload.discarded_at }.to(nil)
         end
       end
@@ -469,6 +515,15 @@ RSpec.describe Discard::Model do
         expect(post.discard).to be false
         expect(post).not_to be_discarded
       end
+
+      describe '#discard!' do
+        it "raises Discard::RecordNotDiscarded" do
+          expect(post).to receive(:do_before_discard) { abort_callback }
+          expect {
+            post.discard!
+          }.to raise_error(Discard::RecordNotDiscarded)
+        end
+      end
     end
   end
 
@@ -524,6 +579,15 @@ RSpec.describe Discard::Model do
         expect(post).to receive(:do_before_undiscard) { abort_callback }
         expect(post.undiscard).to be false
         expect(post).to be_discarded
+      end
+
+      describe '#undiscard!' do
+        it "raises Discard::RecordNotDiscarded" do
+          expect(post).to receive(:do_before_undiscard) { abort_callback }
+          expect {
+            post.undiscard!
+          }.to raise_error(Discard::RecordNotUndiscarded)
+        end
       end
     end
   end


### PR DESCRIPTION
Add unsafe/bang methods of `discard` and `undiscard`.

With the addition of this methods if a record fails to discard/undiscard or if the process is aborted with a `before_*` then an error is raised.

This brings the behaviour of the gem more in line with destroy(!)

Closes #4