### PR TITLE
Update instructions for migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,15 @@ class Post < ActiveRecord::Base
 end
 ```
 
+You can either generate a migration using:
+```
+rails generate migration add_discarded_at_to_posts discarded_at:datetime:index
+```
 
+or create one yourself like the one below:
 ``` ruby
 class AddDiscardToPosts < ActiveRecord::Migration[5.0]
-  def up
+  def change
     add_column :posts, :discarded_at, :datetime
     add_index :posts, :discarded_at
   end


### PR DESCRIPTION
When using `up` instead of `change`, there's no easy way to roll back the migration.

Also added instructions on how to generate the migration via the `rails` command.