### PR TITLE
Update readme instructions for devise to use discarded? 

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ If you are using Devise and wish for discarded users to be unable to login and s
 ```
 class User < ActiveRecord::Base
   def active_for_authentication?
-    super && !discarded_at
+    super && !discarded?
   end
 end
 ```


### PR DESCRIPTION
First of all, thanks for this approach, seems way cleaner than paranoia and similar.

This PR is just a small tweak on the README - I believe it's best to rely on the `discarded?` method, especially since many people might be migrating from other gems, and this might need a `self.discard_column = :deleted_at`.