### PR TITLE
Update discard gem to support unique indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
   * `discard_all` and `undiscard_all` now return affected records
   * Add `discard!` and `undiscard!`
   
+### Version 1.1.0
+Release date: ???
+
+* Support unique database indexes for kept records
+* Don't skip validations when trying to discard records
+
 ### Version 1.0.0
 Release date: 2018-03-16
 

--- a/lib/discard/version.rb
+++ b/lib/discard/version.rb
@@ -2,5 +2,5 @@
 
 module Discard
   # Discard version
-  VERSION = "1.0.0".freeze
+  VERSION = "1.1.0".freeze
 end


### PR DESCRIPTION
This supports database-level uniqueness for kept records, using [this solution](https://stackoverflow.com/questions/3492485/mysql-with-soft-deletion-unique-key-and-foreign-key-constraints).

Also, this updates the gem so validation is not skipped when discarding a record. See the specs for an example of this