### PR TITLE
 Add `undiscarded?` and `kept?` both as !discarded?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Add `discard_all!` and `undiscard_all!`
+* Add `undiscarded?` and `kept?` to match the scopes of the same names
 
 ### Version 1.1.0
 Release date: 2019-05-03

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ post = Post.first   # => #<Post id: 1, ...>
 post.discard        # => true
 post.discard!       # => Discard::RecordNotDiscarded: Failed to discard the record
 post.discarded?     # => true
+post.undiscarded?   # => false
+post.kept?          # => false
 post.discarded_at   # => 2017-04-18 18:49:49 -0700
 
 Post.all             # => [#<Post id: 1, ...>]
@@ -126,6 +128,10 @@ class Comment < ActiveRecord::Base
 
   include Discard::Model
   scope :kept, -> { undiscarded.joins(:post).merge(Post.kept) }
+
+  def kept?
+    undiscarded? && post.kept?
+  end
 end
 
 Comment.kept

--- a/lib/discard/model.rb
+++ b/lib/discard/model.rb
@@ -106,6 +106,12 @@ module Discard
       self[self.class.discard_column].present?
     end
 
+    # @return [Boolean] false if this record has been discarded, otherwise true
+    def undiscarded?
+      !discarded?
+    end
+    alias kept? undiscarded?
+
     # Discard the record in the database
     #
     # @return [Boolean] true if successful, otherwise false

--- a/spec/discard/model_spec.rb
+++ b/spec/discard/model_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Discard::Model do
       end
 
       it "should be kept?" do
-        expect(post).to be_undiscarded
+        expect(post).to be_kept
       end
 
       describe '#discard' do

--- a/spec/discard/model_spec.rb
+++ b/spec/discard/model_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe Discard::Model do
         expect(post).not_to be_discarded
       end
 
+      it "should be undiscarded?" do
+        expect(post).to be_undiscarded
+      end
+
+      it "should be kept?" do
+        expect(post).to be_undiscarded
+      end
+
       describe '#discard' do
         it "sets discarded_at" do
           expect {
@@ -109,6 +117,14 @@ RSpec.describe Discard::Model do
 
       it "should be discarded?" do
         expect(post).to be_discarded
+      end
+
+      it "should not be undiscarded?" do
+        expect(post).to_not be_undiscarded
+      end
+
+      it "should not be kept?" do
+        expect(post).to_not be_kept
       end
 
       describe '#discard' do
@@ -269,6 +285,14 @@ RSpec.describe Discard::Model do
         expect(post).not_to be_discarded
       end
 
+      it "should be undiscarded?" do
+        expect(post).to be_undiscarded
+      end
+
+      it "should be kept?" do
+        expect(post).to be_kept
+      end
+
       describe '#discard' do
         it "sets discarded_at" do
           expect {
@@ -319,6 +343,14 @@ RSpec.describe Discard::Model do
 
       it "should be discarded?" do
         expect(post).to be_discarded
+      end
+
+      it "should not be undiscarded?" do
+        expect(post).to_not be_undiscarded
+      end
+
+      it "should not be kept?" do
+        expect(post).to_not be_kept
       end
 
       describe '#discard' do

--- a/spec/discard/model_spec.rb
+++ b/spec/discard/model_spec.rb
@@ -451,9 +451,16 @@ RSpec.describe Discard::Model do
         2.times { user1.comments.create! }
 
         user1.comments.discard_all
-
-        expect(user1.comments).to all(be_discarded)
-        expect(user2.comments).to all(be_undiscarded)
+        user1.comments.each do |comment|
+          expect(comment).to be_discarded
+          expect(comment).to_not be_undiscarded
+          expect(comment).to_not be_kept
+        end
+        user2.comments.each do |comment|
+          expect(comment).to_not be_discarded
+          expect(comment).to be_undiscarded
+          expect(comment).to be_kept
+        end
       end
     end
   end


### PR DESCRIPTION
This allows, for example: `post.author&.kept?` rather than `post.author && !post.author.discarded?`

Also, by having both `#undiscarded?` and `#kept?` we can separate 'am I or my parent discarded' vs 'am I discarded' in the same way that the `.undiscarded` and `.kept` scopes do.