### PR TITLE
Expanding compatibility into Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ env:
     - RAILS_VERSION='~> 5.0.0'
     - RAILS_VERSION='~> 5.1.0'
     - RAILS_VERSION='~> 5.2.x'
+    - RAILS_VERSION='~> 6'
 before_install: gem install bundler -v 1.14.6

--- a/discard.gemspec
+++ b/discard.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 4.2", "< 6"
+  spec.add_dependency "activerecord", ">= 4.2", "< 7"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.5.0"


### PR DESCRIPTION
There was no change in Rails 6 that made Discard incompatible, requirements in gemspec should reflect that.