### PR TITLE
document value of discarded_at after undiscard

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ end
 ```ruby
 post = Post.first   # => #<Post id: 1, ...>
 post.undiscard      # => true
+post.discarded_at   # => nil
 ```
 
 ***From a controller***


### PR DESCRIPTION
One might imagine that an object once-discarded but later undiscarded might somehow retain data in the `discarded_at` field, though one would be incorrect.