### PR TITLE
Add *_all! methods

### DIFF
--- a/lib/discard/model.rb
+++ b/lib/discard/model.rb
@@ -80,6 +80,25 @@ module Discard
       def undiscard_all
         discarded.each(&:undiscard)
       end
+
+      # Undiscards the records by instantiating each
+      # record and calling its {#undiscard!} method.
+      # Each object's callbacks are executed.
+      # Returns the collection of objects that were undiscarded.
+      #
+      # Note: Instantiation, callback execution, and update of each
+      # record can be time consuming when you're undiscarding many records at
+      # once. It generates at least one SQL +UPDATE+ query per record (or
+      # possibly more, to enforce your callbacks). If you want to undiscard many
+      # rows quickly, without concern for their associations or callbacks, use
+      # #update_all!(discarded_at: nil) instead.
+      #
+      # ==== Examples
+      #
+      #   Person.where(age: 0..18).undiscard_all!
+      def undiscard_all!
+        discarded.each(&:undiscard!)
+      end
     end
 
     # @return [Boolean] true if this record has been discarded, otherwise false

--- a/lib/discard/model.rb
+++ b/lib/discard/model.rb
@@ -43,6 +43,25 @@ module Discard
         kept.each(&:discard)
       end
 
+      # Discards the records by instantiating each
+      # record and calling its {#discard!} method.
+      # Each object's callbacks are executed.
+      # Returns the collection of objects that were discarded.
+      #
+      # Note: Instantiation, callback execution, and update of each
+      # record can be time consuming when you're discarding many records at
+      # once. It generates at least one SQL +UPDATE+ query per record (or
+      # possibly more, to enforce your callbacks). If you want to discard many
+      # rows quickly, without concern for their associations or callbacks, use
+      # #update_all!(discarded_at: Time.current) instead.
+      #
+      # ==== Examples
+      #
+      #   Person.where(age: 0..18).discard_all!
+      def discard_all!
+        kept.each(&:discard!)
+      end
+
       # Undiscards the records by instantiating each
       # record and calling its {#undiscard} method.
       # Each object's callbacks are executed.

--- a/spec/discard/model_spec.rb
+++ b/spec/discard/model_spec.rb
@@ -426,6 +426,30 @@ RSpec.describe Discard::Model do
     end
   end
 
+  describe '.discard_all!' do
+    with_model :Post, scope: :all do
+      table do |t|
+        t.string :title
+        t.datetime :discarded_at
+        t.timestamps null: false
+      end
+
+      model do
+        include Discard::Model
+      end
+    end
+
+    let!(:post) { Post.create!(title: "My very first post") }
+    let!(:post2) { Post.create!(title: "A second post") }
+
+    it "can discard all posts" do
+      expect {
+        Post.discard_all!
+      }.to   change { post.reload.discarded? }.to(true)
+        .and change { post2.reload.discarded? }.to(true)
+    end
+  end
+
   describe '.undiscard_all' do
     with_model :Post, scope: :all do
       table do |t|

--- a/spec/discard/model_spec.rb
+++ b/spec/discard/model_spec.rb
@@ -486,6 +486,30 @@ RSpec.describe Discard::Model do
     end
   end
 
+  describe '.undiscard_all!' do
+    with_model :Post, scope: :all do
+      table do |t|
+        t.string :title
+        t.datetime :discarded_at
+        t.timestamps null: false
+      end
+
+      model do
+        include Discard::Model
+      end
+    end
+
+    let!(:post) { Post.create!(title: "My very first post", discarded_at: Time.now) }
+    let!(:post2) { Post.create!(title: "A second post", discarded_at: Time.now) }
+
+    it "can undiscard all posts" do
+      expect {
+        Post.undiscard_all!
+      }.to   change { post.reload.discarded? }.to(false)
+        .and change { post2.reload.discarded? }.to(false)
+    end
+  end
+
   describe 'discard callbacks' do
     with_model :Post, scope: :all do
       table do |t|


### PR DESCRIPTION
I noticed there wasn't any bang version of `discard_all` and `undiscard_all`.

I didn't copy all the tests for those methods because I didn't think they would add much value since it's nearly the same as the versions without a bang, but I can if it's suggested.

I was also wondering if there is any rational behind not having these methods in a transaction?