### PR TITLE
CI: Use ruby 2.4.9, 2.5.7, 2.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 rvm:
   - 2.2.10
   - 2.3.8
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 env:
   matrix:
     - RAILS_VERSION='~> 4.2.0' SQLITE_VERSION='~> 1.3.6'
@@ -20,5 +20,5 @@ matrix:
       env: RAILS_VERSION='~> 6.0.0.beta3'
     - rvm: 2.3.8
       env: RAILS_VERSION='~> 6.0.0.beta3'
-    - rvm: 2.4.6
+    - rvm: 2.4.9
       env: RAILS_VERSION='~> 6.0.0.beta3'


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known