### PR TITLE
Propose to use safer migration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ rails generate migration add_discarded_at_to_posts discarded_at:datetime:index
 or create one yourself like the one below:
 ``` ruby
 class AddDiscardToPosts < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
   def change
     add_column :posts, :discarded_at, :datetime
-    add_index :posts, :discarded_at
+    add_index :posts, :discarded_at, algorithm: :concurrently
   end
 end
 ```


### PR DESCRIPTION
Adding an index non-concurrently locks the table, it would be awesome to suggest a safer migration in README.