### PR TITLE
Update README.md to reflect correct undiscarding associations in callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ class Post < ActiveRecord::Base
   end
 
   after_undiscard do
-    comments.undiscard_all
+    comments.with_discarded.undiscard_all
   end
 end
 ```
@@ -208,7 +208,7 @@ end
 
 `scope.update_all(discarded_at: Time.current)`
 or
-`scope.update_all(discarded_at: nil)`
+`scope.with_discarded.update_all(discarded_at: nil)`
 
 #### Working with Devise
 


### PR DESCRIPTION
Using the readme example, I was unable to undiscard associations in callbacks without including discarded records of scope. With the fixed examples in the updated readme of this pull request, it seems to fix it and work. Thanks!