### PR TITLE
Update ActiveRecord dependency for Rails 7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
           - ~> 5.1.0
           - ~> 5.2.0
           - ~> 6.0.0
+          - ~> 6.1.0
+          - ~> main
     container: docker://ruby
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           - ~> 5.2.0
           - ~> 6.0.0
           - ~> 6.1.0
-          - ~> main
+          - ~> 7.0.0.alpha2
     container: docker://ruby
     steps:
     - uses: actions/checkout@v1

--- a/discard.gemspec
+++ b/discard.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 4.2", "< 7"
+  spec.add_dependency "activerecord", ">= 4.2", "< 8"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.5.0"


### PR DESCRIPTION
Rails 7 is close to being released. This PR adds support for `ActiveRecord` 7.x. to the gemspec.