### PR TITLE
GitHub workflow requires minimum of Rails 7 final

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           - ~> 5.2.0
           - ~> 6.0.0
           - ~> 6.1.0
-          - ~> 7.0.0.alpha2
+          - ~> 7.0.0
     container: docker://ruby
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Previously this was pinned to the second alpha of Rails 7, but since Rails 7.0 final has been released we can now pin to this final release.