### PR TITLE
Load an appropriate Ruby version for each Rails version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,18 @@ jobs:
     name: Test on Rails ${{ matrix.rails_version }}
     strategy:
       matrix:
-        rails_version:
-          - ~> 5.1.0
-          - ~> 5.2.0
-          - ~> 6.0.0
-          - ~> 6.1.0
-          - ~> 7.0.0
-    container: docker://ruby
+        include:
+          - rails_version: ~> 7.0.0
+            ruby_version: 3.1
+          - rails_version: ~> 6.1.0
+            ruby_version: '3.0'
+          - rails_version: ~> 6.0.0
+            ruby_version: 2.7
+          - rails_version: ~> 5.2.0
+            ruby_version: 2.6
+          - rails_version: ~> 5.1.0
+            ruby_version: 2.5
+    container: docker://ruby:${{ matrix.ruby_version }}
     steps:
     - uses: actions/checkout@v1
     - name: Build and test


### PR DESCRIPTION
This updates the CI build matrix to use an appropriate Ruby version for each Rails version.  This fixes failing CI.