### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
       matrix:
         include:
           - rails_version: ~> 7.0.0
+            ruby_version: 3.2
+          - rails_version: ~> 7.0.0
             ruby_version: 3.1
           - rails_version: ~> 6.1.0
             ruby_version: '3.0'
@@ -25,13 +27,13 @@ jobs:
             ruby_version: 2.6
           - rails_version: ~> 5.1.0
             ruby_version: 2.5
-    container: docker://ruby:${{ matrix.ruby_version }}
+    env:
+      RAILS_VERSION: ${{ matrix.rails_version }}
     steps:
     - uses: actions/checkout@v3
-    - name: Build and test
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        bundle exec rake
-      env:
-        RAILS_VERSION:  ${{ matrix.rails_version }}
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby_version }}
+        bundler-cache: true
+    - name: Test
+      run: bundle exec rake 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Test on Rails ${{ matrix.rails_version }}
+    name: Test on Rails ${{ matrix.rails_version }} and Ruby ${{ matrix.ruby_version }}
     strategy:
       matrix:
         include:

--- a/discard.gemspec
+++ b/discard.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord", ">= 4.2", "< 8"
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec", "~> 3.5.0"
   spec.add_development_dependency "database_cleaner", "~> 1.5"
   spec.add_development_dependency "with_model", "~> 2.0"


### PR DESCRIPTION
To get this to run successfully I needed to:

1. Switch to use ruby/setup-ruby, so a compatible version of bundler is installed for Ruby 2.5
2. Loosen the rake requirement in the gemspec, so a Ruby 3.2 compatible version of rake can be used.

Runs green on my fork.