### PR TITLE
Add testing on Rails 7.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
     strategy:
       matrix:
         include:
+          - rails_version: ~> 7.1.0
+            ruby_version: 3.2
+          - rails_version: ~> 7.1.0
+            ruby_version: 3.1
           - rails_version: ~> 7.0.0
             ruby_version: 3.2
           - rails_version: ~> 7.0.0


### PR DESCRIPTION
This adds Rails 7.1 to CI.  Runs green on my fork.