### PR TITLE
More descriptive error messages

### DIFF
--- a/lib/discard/model.rb
+++ b/lib/discard/model.rb
@@ -159,11 +159,23 @@ module Discard
     private
 
     def _raise_record_not_discarded
-      raise ::Discard::RecordNotDiscarded.new("Failed to discard the record", self)
+      raise ::Discard::RecordNotDiscarded.new(disacrded_fail_message, self)
     end
 
     def _raise_record_not_undiscarded
-      raise ::Discard::RecordNotUndiscarded.new("Failed to undiscard the record", self)
+      raise ::Discard::RecordNotUndiscarded.new(undiscarded_fail_message, self)
+    end
+
+    def disacrded_fail_message
+      return "A discarded record cannot be discarded" if discarded?
+
+      "Failed to discard the record"
+    end
+
+    def undiscarded_fail_message
+      return "An undiscarded record cannot be undiscarded" if undiscarded?
+
+      "Failed to undiscard the record"
     end
   end
 end

--- a/lib/discard/model.rb
+++ b/lib/discard/model.rb
@@ -159,14 +159,14 @@ module Discard
     private
 
     def _raise_record_not_discarded
-      raise ::Discard::RecordNotDiscarded.new(disacrded_fail_message, self)
+      raise ::Discard::RecordNotDiscarded.new(discarded_fail_message, self)
     end
 
     def _raise_record_not_undiscarded
       raise ::Discard::RecordNotUndiscarded.new(undiscarded_fail_message, self)
     end
 
-    def disacrded_fail_message
+    def discarded_fail_message
       return "A discarded record cannot be discarded" if discarded?
 
       "Failed to discard the record"

--- a/spec/discard/model_spec.rb
+++ b/spec/discard/model_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Discard::Model do
         it "raises Discard::RecordNotUndiscarded" do
           expect {
             post.undiscard!
-          }.to raise_error(Discard::RecordNotUndiscarded)
+          }.to raise_error(Discard::RecordNotUndiscarded, 'An undiscarded record cannot be undiscarded')
         end
       end
     end
@@ -153,7 +153,7 @@ RSpec.describe Discard::Model do
         it "raises Discard::RecordNotDiscarded" do
           expect {
             post.discard!
-          }.to raise_error(Discard::RecordNotDiscarded)
+          }.to raise_error(Discard::RecordNotDiscarded, "A discarded record cannot be discarded")
         end
       end
 
@@ -616,7 +616,7 @@ RSpec.describe Discard::Model do
           expect(post).to receive(:do_before_discard) { abort_callback }
           expect {
             post.discard!
-          }.to raise_error(Discard::RecordNotDiscarded)
+          }.to raise_error(Discard::RecordNotDiscarded, "Failed to discard the record")
         end
       end
     end
@@ -677,11 +677,11 @@ RSpec.describe Discard::Model do
       end
 
       describe '#undiscard!' do
-        it "raises Discard::RecordNotDiscarded" do
+        it "raises Discard::RecordNotUndiscarded" do
           expect(post).to receive(:do_before_undiscard) { abort_callback }
           expect {
             post.undiscard!
-          }.to raise_error(Discard::RecordNotUndiscarded)
+          }.to raise_error(Discard::RecordNotUndiscarded, "Failed to undiscard the record")
         end
       end
     end


### PR DESCRIPTION
While working with the discard gem I noticed that you can't discard already discarded records. There wasn't any mention of this in the docs and the error message wasn't very helpful. It cost me some time debugging.

Hopefully this saves others a bit of time :)