### PR TITLE
Add Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,28 @@ Post.with_discarded.discarded  # Only discarded posts
 If you're migrating from paranoia, you might want to continue using the same
 column.
 
+You can either configure it per model basis:
+
 ``` ruby
 class Post < ActiveRecord::Base
   include Discard::Model
   self.discard_column = :deleted_at
+end
+```
+
+Or for the project:
+
+```bash
+rails generate discard:install
+```
+
+And configure:
+
+`config/initializers/discard.rb`
+
+```ruby
+Discard.configure do |config|
+  config.discard_column = :deleted_at
 end
 ```
 

--- a/lib/discard.rb
+++ b/lib/discard.rb
@@ -5,3 +5,8 @@ require "active_record"
 require "discard/version"
 require "discard/errors"
 require "discard/model"
+require "discard/configure"
+
+module Discard
+  extend Configure
+end

--- a/lib/discard/configuration.rb
+++ b/lib/discard/configuration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Discard
+  class Configuration
+    attr_accessor :discard_column
+
+    def initialize
+      self.discard_column = :discarded_at
+    end
+  end
+end

--- a/lib/discard/configure.rb
+++ b/lib/discard/configure.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "discard/configuration"
+
+module Discard
+  module Configure
+    attr_writer :configuration
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield(configuration)
+    end
+  end
+end

--- a/lib/discard/model.rb
+++ b/lib/discard/model.rb
@@ -11,7 +11,7 @@ module Discard
 
     included do
       class_attribute :discard_column
-      self.discard_column = :discarded_at
+      self.discard_column = Discard.configuration.discard_column
 
       scope :kept, ->{ undiscarded }
       scope :undiscarded, ->{ where(discard_column => nil) }

--- a/lib/generators/discard/install/templates/discard.rb.tt
+++ b/lib/generators/discard/install/templates/discard.rb.tt
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "discard"
+
+Discard.configure do |config|
+  # config.discard_column = :deleted_at # default :discarded_at
+end

--- a/lib/generators/discard/install_generator.rb
+++ b/lib/generators/discard/install_generator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Discard
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      source_root File.expand_path("install/templates", __dir__)
+
+      desc "rails generate discard:install"
+
+      def copy_initializer_file
+        template "discard.rb.tt", "config/initializers/discard.rb"
+      end
+    end
+  end
+end

--- a/spec/discard/configuration_spec.rb
+++ b/spec/discard/configuration_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Discard
+  RSpec.describe Configuration do
+    describe '#default' do
+      specify do
+        expect(subject.discard_column).to eql(:discarded_at)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add Configuration, as a convenience to adopt Discard Gem in an established project that already uses a different column name.