### PR TITLE
Validate on undiscard operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,39 @@ def update
 end
 ```
 
+### Validate undiscarded records
+
+The `undiscard` method supports a validation context option that's useful when you need to run model validations during
+undiscard operations. This ensures that undiscarded records meet the same validation criteria as kept records.
+
+```ruby
+class Post < ActiveRecord::Base
+  include Discard::Model
+  
+  # Ensure unique titles in kept posts
+  validates :title, uniqueness: { conditions: -> { kept } }
+
+  # Ensure unique titles when undiscarding posts
+  validates :title, uniqueness: true, on: :undiscard
+end
+
+# Uses the default :undiscard context
+post.undiscard # Validates with :undiscard context
+
+# Use a custom validation context
+post.undiscard(context: :custom_context)  # Validates with :custom_context
+
+# Skip validations entirely
+post.undiscard(context: nil) # Skips validations
+```
+
+The `undiscard!` method also accepts the same context option:
+
+```ruby
+# Raises Discard::RecordNotUndiscarded if validation fails
+post.undiscard!(context: :custom_context)
+```
+
 #### Working with associations
 
 Under paranoia, soft deleting a record will destroy any `dependent: :destroy`


### PR DESCRIPTION
## Problem

Undiscarding a record may lead to data integrity issues. For example:

```ruby
class Post < ActiveRecord::Base
  include Discard::Model

  validates :title, uniqueness: { conditions: -> { kept } }
end

post1 = Post.create(title: "This is a unique title")
post2 = Post.create(title: "This is a unique title") # ✅ validation error as the title is not unique
post1.discard # ✅ title should be available

post2 = Post.create(title: "This is a unique title") # ✅ allowed because the previous post is discarded
post1.undiscard # => true ❌ now we have two records with the same title
```

This happens because the gem uses [`#update_attribute` to undiscard records, which skips validations:](https://api.rubyonrails.org/v5.2/classes/ActiveRecord/Persistence.html#method-i-update_attribute)

```ruby
def undiscard
  return false unless discarded?
  run_callbacks(:undiscard) do
    update_attribute(self.class.discard_column, nil)
  end
end
```

## Solution

Use `#update` instead of `#update_attribute` with a default, configurable and ommittable [validation context](https://guides.rubyonrails.org/active_record_validations.html#custom-contexts):

```ruby
class Post < ActiveRecord::Base
  include Discard::Model

  # Ensure unique titles in kept posts
  validates :title, uniqueness: { conditions: -> { kept } }

  # Ensure unique titles when undiscarding posts
  validates :title, uniqueness: true, on: :undiscard
end

post1 = Post.create(title: "This is a unique title")
post2 = Post.create(title: "This is a unique title") # ✅ validation error as the title is not unique
post1.discard # => true - title should be available

post2 = Post.create(title: "This is a unique title") # ✅ allowed because the previous post is discarded
post1.undiscard # => false  ✅ not allowed because there is already a post with this unique title
post1.errors # => #<ActiveModel::Errors [#<ActiveModel::Error attribute=title, type=taken, options={value: "This is a unique title"}>]>
```

## Cons

Users must write some validations twice—one with the explicit context and the other without.

## Design choices

- The context of `#create` is `:create`. The context of `#update` is `:update`. The context of `#destroy` is `:destroy`. So I named the context of `#discard` as `:discard`.
- I kept the original behaviour using `update_attribute` when we call `undiscard` with a `nil` context: `discarded_post.undiscard(context: nil)`
- This may be a breaking change for some users, as they may not expect validations to kick in. I can make this behaviour configurable, but I wanted to float the idea by the maintainers to see if it makes sense first.