### PR TITLE
Wrap discard methods in a transaction

### DIFF
--- a/lib/discard/model.rb
+++ b/lib/discard/model.rb
@@ -117,8 +117,11 @@ module Discard
     # @return [Boolean] true if successful, otherwise false
     def discard
       return false if discarded?
-      run_callbacks(:discard) do
-        update_attribute(self.class.discard_column, Time.current)
+
+      _in_discard_transaction do
+        run_callbacks(:discard) do
+          update_attribute(self.class.discard_column, Time.current)
+        end
       end
     end
 
@@ -139,8 +142,11 @@ module Discard
     # @return [Boolean] true if successful, otherwise false
     def undiscard
       return false unless discarded?
-      run_callbacks(:undiscard) do
-        update_attribute(self.class.discard_column, nil)
+
+      _in_discard_transaction do
+        run_callbacks(:undiscard) do
+          update_attribute(self.class.discard_column, nil)
+        end
       end
     end
 
@@ -157,6 +163,18 @@ module Discard
     end
 
     private
+
+    def _in_discard_transaction
+      previous_discard_value = public_send(self.class.discard_column)
+
+      with_transaction_returning_status do
+        yield
+      end
+    rescue
+      assign_attributes(self.class.discard_column => previous_discard_value)
+
+      raise
+    end
 
     def _raise_record_not_discarded
       raise ::Discard::RecordNotDiscarded.new(discarded_fail_message, self)


### PR DESCRIPTION
> cherry-pick of #84

---

This seeks to solve issue: https://github.com/jhawthorn/discard/issues/77

Given the situation where a `before/after` callback fails, particularly
with related records, we shouldn't still discard records.

Note: This is leveraging a private API that exists in
[ActiveRecord::Transactions](https://github.com/rails/rails/blob/cd2949d2d936daa89b7e23f816f1c004aee85461/activerecord/lib/active_record/transactions.rb#L345)
