### PR TITLE
Wrap discard methods in a transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Require ActiveRecord >= 7.0; drop support for Rails 6.x and earlier
+* Wrap `#discard` / `#undiscard` in a transaction so callback exceptions roll back the DB write (#84, #77)
 
 ### Version 1.4.0
 Release date: 2024-11-05

--- a/lib/discard/model.rb
+++ b/lib/discard/model.rb
@@ -117,8 +117,11 @@ module Discard
     # @return [Boolean] true if successful, otherwise false
     def discard
       return false if discarded?
-      run_callbacks(:discard) do
-        update_attribute(self.class.discard_column, Time.current)
+
+      with_transaction_returning_status do
+        run_callbacks(:discard) do
+          update_attribute(self.class.discard_column, Time.current)
+        end
       end
     end
 
@@ -139,8 +142,11 @@ module Discard
     # @return [Boolean] true if successful, otherwise false
     def undiscard
       return false unless discarded?
-      run_callbacks(:undiscard) do
-        update_attribute(self.class.discard_column, nil)
+
+      with_transaction_returning_status do
+        run_callbacks(:undiscard) do
+          update_attribute(self.class.discard_column, nil)
+        end
       end
     end
 

--- a/spec/discard/model_spec.rb
+++ b/spec/discard/model_spec.rb
@@ -686,4 +686,78 @@ RSpec.describe Discard::Model do
       end
     end
   end
+
+  describe 'when a callback raises during discard' do
+    with_model :Post, scope: :all do
+      table do |t|
+        t.datetime :discarded_at
+        t.timestamps null: false
+      end
+
+      model do
+        include Discard::Model
+        after_discard :boom
+
+        def boom
+          raise "boom"
+        end
+      end
+    end
+
+    let!(:post) { Post.create! }
+
+    it "propagates the exception" do
+      expect { post.discard }.to raise_error("boom")
+    end
+
+    it "rolls back the DB write" do
+      expect { post.discard rescue nil }
+        .not_to change { Post.find(post.id).discarded? }
+    end
+
+    it "clears dirty tracking on the rolled-back attribute" do
+      post.discard rescue nil
+      expect(post.discarded_at_changed?).to be false
+    end
+
+    describe '#discard!' do
+      it "propagates the callback exception" do
+        expect { post.discard! }.to raise_error("boom")
+      end
+    end
+  end
+
+  describe 'when a callback raises during undiscard' do
+    with_model :Post, scope: :all do
+      table do |t|
+        t.datetime :discarded_at
+        t.timestamps null: false
+      end
+
+      model do
+        include Discard::Model
+        after_undiscard :boom
+
+        def boom
+          raise "boom"
+        end
+      end
+    end
+
+    let!(:post) { Post.create!(discarded_at: Time.current) }
+
+    it "propagates the exception" do
+      expect { post.undiscard }.to raise_error("boom")
+    end
+
+    it "rolls back the DB write" do
+      expect { post.undiscard rescue nil }
+        .not_to change { Post.find(post.id).discarded? }
+    end
+
+    it "clears dirty tracking on the rolled-back attribute" do
+      post.undiscard rescue nil
+      expect(post.discarded_at_changed?).to be false
+    end
+  end
 end


### PR DESCRIPTION
We didn't have enough PRs with the same name, so this is _my_ cherry pick of #84. (@grncdr I actually did this mostly last night before you'd pushed up yours, but thank you for doing that! My bad for not saying I would do it.)

This varies from the original mainly in that it removes the error handling which should be unnecessary in modern versions of ActiveRecord.